### PR TITLE
Select datetime schedule intervals only

### DIFF
--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -1,5 +1,6 @@
 import typing
 from typing import List, Tuple, Optional, Generator, NamedTuple, Dict
+import datetime
 
 from dataclasses import dataclass
 import itertools
@@ -38,15 +39,21 @@ def get_dag_schedule_interval() -> List[DagScheduleInterval]:
         DagModel.dag_id
     ).all()
 
+    filtered_schedule_intervals = select_datetime_schedule_intervals(sql_res)
+
     res = [
         DagScheduleInterval(
             dag_id = i.dag_id,
-            cnt = int(i.schedule_interval.total_seconds())
+            cnt = i.schedule_interval.total_seconds()
         )
-        for i in sql_res
+        for i in filtered_schedule_intervals
     ]
 
     return res
+
+def select_datetime_schedule_intervals(schedule_intervals) -> List[datetime.timedelta]:
+    return [i  for i in schedule_intervals if isinstance(i.schedule_interval, datetime.timedelta)]
+
 @dataclass
 class DagStatusInfo:
     dag_id: str

--- a/tests/dags/slow_dag.py
+++ b/tests/dags/slow_dag.py
@@ -17,7 +17,7 @@ default_args = {
 
 dag = DAG(
     'slow_dag',
-    schedule_interval=timedelta(hours=5),
+    schedule_interval='@hourly',
     default_args=default_args,
     catchup=False,
     params={
@@ -35,7 +35,7 @@ dummy1 = DummyOperator(
 dummy2 = BashOperator(
     task_id='dummy_task_2',
     dag=dag,
-    bash_command='sleep 60'
+    bash_command='sleep 10'
 )
 
 dummy1 >> dummy2


### PR DESCRIPTION
schedule_interval can return either datetime.timedelta or string. We can not use strings so these ones are rejected now.